### PR TITLE
Purchases implementation

### DIFF
--- a/lib/nubank_api/features/purchases.ex
+++ b/lib/nubank_api/features/purchases.ex
@@ -1,0 +1,123 @@
+defmodule NubankAPI.Feature.Purchases do
+  @moduledoc """
+  Module responsible for handling the data from the :purchases endpoint.
+  """
+
+  use NubankAPI.Feature
+  alias NubankAPI.{Access, Purchase}
+
+  @link :purchases
+  @known_categories [
+    :lazer,
+    :outros,
+    :transporte,
+    :eletrônicos,
+    :restaurante,
+    :vestuário,
+    :serviços,
+    :casa,
+    :supermercado,
+    :educação,
+    :viagem
+  ]
+
+  @known_status [
+    :settled,
+    :unsettled,
+    :canceled,
+    :expired,
+    :reversed
+  ]
+
+  @known_event_types [
+    :transaction_card_not_present,
+    :transaction_card_present
+  ]
+
+  @doc """
+  Fetches purchases information
+
+  ## Examples
+
+      iex> NubankAPI.Feature.Purchases.fetch_purchases(access)
+      {:ok, [%SavingsAccount{}]}
+
+  """
+  def fetch_purchases(access = %Access{}, opts \\ []) do
+    with {:ok, %{"transactions" => purchases}} <- @http.get(@link, access),
+         parsed_purchases <- Enum.map(purchases, &parse_purchase/1) do
+      {:ok, parsed_purchases}
+    end
+  end
+
+  @doc """
+  List the known purchase categories
+
+  ## Examples
+
+      iex> NubankAPI.Feature.Purchases.list_known_categories()
+      [ :lazer, :outros, :transporte, :eletrônicos, :restaurante, :vestuário, :serviços, :casa, :supermercado, :educação, :viagem ]
+  ]
+  """
+  def list_known_categories, do: @known_categories
+
+  @doc """
+  List the known purchase status
+
+  ## Examples
+
+      iex> NubankAPI.Feature.Purchases.list_known_status()
+      [ :settled, :unsettled, :canceled, :expired, :reversed ]
+  ]
+  """
+  def list_known_status, do: @known_status
+
+  @doc """
+  List the known purchase event types
+
+  ## Examples
+
+      iex> NubankAPI.Feature.Purchases.list_known_categories()
+      [ :transaction_card_not_present, :transaction_card_present ]
+  """
+  def list_known_event_types, do: @known_event_types
+
+  defp parse_purchase(purchase) do
+    %Purchase{
+      account: purchase["account"],
+      acquirer_id: purchase["acquirer_id"],
+      amount: purchase["amount"],
+      approved_reasons: purchase["approved_reasons"],
+      auth_code: purchase["auth_code"],
+      capture_mode: purchase["capture_mode"],
+      card: purchase["card"],
+      category: purchase["category"],
+      chargebacks: purchase["chargebacks"],
+      charges: purchase["charges"],
+      charges_list: purchase["charges_list"],
+      country: purchase["country"],
+      customer: purchase["customer"],
+      event_type: purchase["event_type"],
+      id: purchase["id"],
+      expires_on: purchase["expires_on"],
+      mcc: purchase["mcc"],
+      merchant_id: purchase["merchant_id"],
+      merchant_name: purchase["merchant_name"],
+      original_merchant_name: purchase["original_merchant_name"],
+      postcode: purchase["postcode"],
+      precise_amount: purchase["precise_amount"],
+      recurring: purchase["recurring"],
+      secure_code: purchase["secure_code"],
+      source: purchase["source"],
+      stand_in: purchase["stand_in"],
+      status: purchase["status"],
+      time: purchase["time"],
+      time_wallclock: purchase["time_wallclock"],
+      lon: purchase["lon"],
+      lat: purchase["lat"],
+      tags: purchase["tags"],
+      fx: purchase["fx"],
+      _links: purchase["_links"]
+    }
+  end
+end

--- a/lib/nubank_api/purchase.ex
+++ b/lib/nubank_api/purchase.ex
@@ -1,0 +1,40 @@
+defmodule NubankAPI.Purchase do
+  @moduledoc false
+
+  defstruct [
+    :account,
+    :acquirer_id,
+    :amount,
+    :approved_reasons,
+    :auth_code,
+    :capture_mode,
+    :card,
+    :category,
+    :chargebacks,
+    :charges,
+    :charges_list,
+    :country,
+    :customer,
+    :event_type,
+    :id,
+    :expires_on,
+    :mcc,
+    :merchant_id,
+    :merchant_name,
+    :original_merchant_name,
+    :postcode,
+    :precise_amount,
+    :recurring,
+    :secure_code,
+    :source,
+    :stand_in,
+    :status,
+    :time,
+    :time_wallclock,
+    :lon,
+    :lat,
+    :_links,
+    :tags,
+    :fx
+  ]
+end

--- a/test/features/purchases_test.exs
+++ b/test/features/purchases_test.exs
@@ -1,0 +1,72 @@
+defmodule NubankAPI.Feature.PurchasesTest do
+  use ExUnit.Case, async: true
+  import Mox
+
+  alias NubankAPI.{Access, Purchase}
+  alias NubankAPI.Feature.Purchases
+  alias NubankAPI.Mock.HTTP
+
+  setup do
+    purchases_fixture = NubankAPI.TestHelper.load_fixture(:purchases)
+
+    access = %Access{
+      access_token: "fake_access_token",
+      refresh_before: DateTime.utc_now(),
+      refresh_token: "fake_refresh_token",
+      token_type: "bearer",
+      links: %{
+        puchases: "https://fakeapi.nubank.com.br/purchases"
+      }
+    }
+
+    {:ok, access: access, purchases_fixture: purchases_fixture}
+  end
+
+  describe "NubankAPI.Feature.Purchases.fetch_purchases/1" do
+    test "parses the response from the API to %Purchase{}", %{
+      access: access,
+      purchases_fixture: purchases_fixture
+    } do
+      expect(HTTP, :get, fn :purchases, ^access -> {:ok, purchases_fixture} end)
+      expected_length = Enum.count(purchases_fixture["transactions"])
+
+      {:ok, purchases} = Purchases.fetch_purchases(access)
+
+      assert Enum.count(purchases) == expected_length
+
+      Enum.each(purchases, fn purchase ->
+        assert %Purchase{} = purchase
+      end)
+    end
+  end
+
+  describe "NubankAPI.Feature.Purchases.list_known_categories/0" do
+    test "return a list of known categories as atoms" do
+      categories = Purchases.list_known_categories()
+
+      Enum.each(categories, fn category ->
+        assert is_atom(category)
+      end)
+    end
+  end
+
+  describe "NubankAPI.Feature.Purchases.list_known_status/0" do
+    test "return a list of known statuses as atoms" do
+      statuses = Purchases.list_known_status()
+
+      Enum.each(statuses, fn status ->
+        assert is_atom(status)
+      end)
+    end
+  end
+
+  describe "NubankAPI.Feature.Purchases.list_known_event_types/0" do
+    test "return a list of known event_types as atoms" do
+      event_types = Purchases.list_known_event_types()
+
+      Enum.each(event_types, fn event_type ->
+        assert is_atom(event_type)
+      end)
+    end
+  end
+end

--- a/test/fixtures/purchases.json
+++ b/test/fixtures/purchases.json
@@ -1,0 +1,186 @@
+{
+  "transactions": [
+      {
+          "category": "lazer",
+          "amount": 1111,
+          "tags": [],
+          "chargebacks": [],
+          "precise_amount": "11.12",
+          "merchant_id": "174020076999",
+          "time": "2018-06-29T07:31:03Z",
+          "charges": 1,
+          "original_merchant_name": "PP*HUMBLEBUNDL HUMBLEB",
+          "postcode": "99999",
+          "type": "card_not_present",
+          "mcc": "lazer",
+          "approved_reasons": [
+              "normal_approval"
+          ],
+          "expires_on": "2018-07-06",
+          "charges_list": [
+              {
+                  "amount": 1111,
+                  "transaction_id": "5k32e038-ac49-4418-bd50-e1cca19cfz94",
+                  "index": 0,
+                  "account_id": "ca2126b4-4ef9-4ba2-299b-308ebaba1bf1",
+                  "precise_amount": "11.11",
+                  "promotion_reason": "settlement",
+                  "status": "historical",
+                  "id": "2j37ecb6-6a2c-42d8-8l76-azac4c0f2b61",
+                  "precise_amount_usd": "12",
+                  "extras": [
+                      {
+                          "name": "iof",
+                          "amount": 111.1111,
+                          "precise_amount": "1.111111"
+                      }
+                  ],
+                  "post_date": "2018-06-30"
+              }
+          ],
+          "source": "upfront_foreign",
+          "capture_mode": {
+              "entry_mode": "e_commerce_chip",
+              "pin_mode": "not_accepted"
+          },
+          "recurring": false,
+          "customer": "aaaa240b-2d5d-2222-95a7-75cecdcaceced",
+          "account": "5a6126b4-8ef9-4za2-999b-508ebaba1bf1",
+          "card": "5a6126b4-7d6b-4815-8ab6-2d65dd0b6002",
+          "secure_code": false,
+          "status": "settled",
+          "id": "5b35e031-aa49-4428-bc50-e1cca19cfe94",
+          "merchant_name": "Pp*Humblebundl Humbleb",
+          "event_type": "transaction_card_not_present",
+          "_links": {
+              "category": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "chargeback_reasons_v4": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "notify_geo": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "categories": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "chargeback": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "create_tag": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "chargeback_reasons": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "merchant": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "self": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              }
+          },
+          "fx": {
+              "currency_origin": "USD",
+              "amount_origin": 1100,
+              "amount_usd": 1100,
+              "precise_amount_origin": "11",
+              "precise_amount_usd": "11",
+              "exchange_rate": 4.01
+          },
+          "auth_code": "Q4XX2F",
+          "acquirer_id": "231497",
+          "stand_in": false,
+          "country": "USA",
+          "time_wallclock": "2018-06-29T04:20:26"
+      },
+      {
+          "category": "transporte",
+          "amount": 2222,
+          "tags": [],
+          "chargebacks": [],
+          "precise_amount": "22.22",
+          "merchant_id": "539701023040201",
+          "time": "2018-08-22T11:04:12Z",
+          "charges": 1,
+          "original_merchant_name": "Uber Do Brasil Tecnolo",
+          "postcode": "33333333",
+          "type": "card_not_present",
+          "mcc": "transporte",
+          "approved_reasons": [
+              "normal_approval"
+          ],
+          "expires_on": "2018-08-29",
+          "charges_list": [
+              {
+                  "amount": 2222,
+                  "transaction_id": "cb7d412c-63ef-479b-a3d5-2de4afb19ad0",
+                  "index": 0,
+                  "account_id": "5a6123q4-8ei9-4fl2-939b-508gbabacbf1",
+                  "precise_amount": "22.22",
+                  "promotion_reason": "settlement",
+                  "status": "historical",
+                  "id": "cb7d412c-63ef-479b-a3d5-2de4afb19ad0",
+                  "extras": [],
+                  "post_date": "2018-08-23"
+              }
+          ],
+          "source": "upfront_national",
+          "capture_mode": {
+              "entry_mode": "e_commerce_chip",
+              "pin_mode": "not_accepted"
+          },
+          "recurring": true,
+          "customer": "cb7d412c-63ef-479b-a3d5-2de4afb19ad0",
+          "account": "cb7d412c-63ef-479b-a3d5-2de4afb19ad0",
+          "card": "cb7d412c-63ef-479b-a3d5-2de4afb19ad0",
+          "secure_code": false,
+          "status": "settled",
+          "id": "cb7d412c-63ef-479b-a3d5-2de4afb19ad0",
+          "lon": -11.1757409,
+          "lat": -11.9324676,
+          "merchant_name": "Uber do Brasil Tecnolo",
+          "event_type": "transaction_card_not_present",
+          "_links": {
+              "category": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "chargeback_reasons_v4": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "notify_geo": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "categories": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "chargeback": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "create_tag": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "chargeback_reasons": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "merchant": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              },
+              "self": {
+                  "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+              }
+          },
+          "auth_code": "QKSZX7",
+          "acquirer_id": "116385",
+          "stand_in": false,
+          "country": "BRA",
+          "time_wallclock": "2018-08-22T08:16:51"
+      }
+  ],
+  "_links": {
+      "updates": {
+          "href": "https://prod-s0-webapp-proxy.nubank.com.br/api/proxy/ABC"
+      }
+  }
+}


### PR DESCRIPTION
Implementation of the purchases endpoint (https://github.com/jeffhsta/nubank_api/issues/20).

The returned object has quite a lot of fields. With that in mind, having filter options as the events and bills_summary does not sound as interesting in my opinion. 